### PR TITLE
Add GeoJSON as a valid file type

### DIFF
--- a/grammars/json.cson
+++ b/grammars/json.cson
@@ -1,5 +1,6 @@
 'fileTypes': [
   'json'
+  'geojson'
 ]
 'name': 'JSON'
 'patterns': [


### PR DESCRIPTION
[GeoJSON](http://en.wikipedia.org/wiki/GeoJSON) is an open standard format for encoding collections of simple geographical features along with their non-spatial attributes using JavaScript Object Notation. It might be useful to automatically highlight it as JSON in the Atom editor.
