### PR TITLE
Fix grammar to validate JSON numbers.

### DIFF
--- a/grammars/json.cson
+++ b/grammars/json.cson
@@ -42,7 +42,7 @@
     'name': 'constant.language.json'
   'number':
     'comment': 'handles integer and decimal numbers'
-    'match': '(?x:         # turn on extended mode\n\t\t\t             -?         # an optional minus\n\t\t\t             (?:\n\t\t\t               0        # a zero\n\t\t\t               |        # ...or...\n\t\t\t               [1-9]    # a 1-9 character\n\t\t\t               \\d*      # followed by zero or more digits\n\t\t\t             )\n\t\t\t             (?:\n\t\t\t               (?:\n\t\t\t                 \\.     # a period\n\t\t\t                 \\d+    # followed by one or more digits\n\t\t\t               )?\n\t\t\t               (?:\n\t\t\t                 [eE]   # an e character\n\t\t\t                 [+-]?  # followed by an option +/-\n\t\t\t                 \\d+    # followed by one or more digits\n\t\t\t               )?       # make exponent optional\n\t\t\t             )?         # make decimal portion optional\n\t\t\t           )'
+    'match': '-?(?=[1-9]|0(?!\\d))\\d+(\\.\\d+)?([eE][+-]?\\d+)?'
     'name': 'constant.numeric.json'
   'object':
     'begin': '\\{'


### PR DESCRIPTION
## #9

The correct regular expression using lookaheads and lookbehinds is:

```js
-?(?=[1-9]|0(?!\\d))\\d+(\\.\\d+)?([eE][+-]?\\d+)?
```

The comments were removed as I couldn't figure out a sane way to squash everything into a single string. Perhaps this grammar was copied verbatim from the TextMate bundle? using some sort of automated tool.

Anyway, maybe it would be more useful to have a separate file with comments for all the regular expressions. What do you think?

[Source](http://stackoverflow.com/questions/2583472/regex-to-validate-json)