### PR TITLE
Line Delimited JSON should parsed with JSON grammar

### DIFF
--- a/grammars/json.cson
+++ b/grammars/json.cson
@@ -6,6 +6,9 @@
   'jslintrc'
   'json'
   'topojson'
+  'jsonl'
+  'ldjson'
+  'ldj'
 ]
 'name': 'JSON'
 'patterns': [


### PR DESCRIPTION
Line Delimited JSON should parsed with the JSON grammar by default

https://github.com/atom/atom/issues/5909