### PR TITLE
add detection of manifest.webapp files

### DIFF
--- a/grammars/json.cson
+++ b/grammars/json.cson
@@ -7,6 +7,7 @@
   'jslintrc'
   'json'
   'topojson'
+  'webapp'
 ]
 'name': 'JSON'
 'patterns': [


### PR DESCRIPTION
This is an extension used by Firefox / Firefox OS for [manifest files](https://developer.mozilla.org/en-US/Apps/Build/Manifest) (which are JSON).