### PR TITLE
add comments support, default comment style to //

### DIFF
--- a/grammars/json.cson
+++ b/grammars/json.cson
@@ -13,7 +13,6 @@
   'schema'
   'topojson'
   'webapp'
-  'config'
 ]
 'name': 'JSON'
 'patterns': [

--- a/grammars/json.cson
+++ b/grammars/json.cson
@@ -147,7 +147,7 @@
   'comments':
     'patterns': [
       {
-        'match': '/{2}.*'
+        'match': '//.*'
         'name': 'comment.single.json'
       }
       {

--- a/grammars/json.cson
+++ b/grammars/json.cson
@@ -13,9 +13,13 @@
   'schema'
   'topojson'
   'webapp'
+  'config'
 ]
 'name': 'JSON'
 'patterns': [
+  {
+    'include': '#comments'
+  }
   {
     'include': '#value'
   }
@@ -32,6 +36,9 @@
         'name': 'punctuation.definition.array.end.json'
     'name': 'meta.structure.array.json'
     'patterns': [
+      {
+        'include': '#comments'
+      }
       {
         'include': '#value'
       }
@@ -64,6 +71,9 @@
     'name': 'meta.structure.dictionary.json'
     'patterns': [
       {
+        'include': '#comments'
+      }
+      {
         'comment': 'the JSON object key'
         'include': '#string'
       }
@@ -78,6 +88,9 @@
             'name': 'punctuation.separator.dictionary.pair.json'
         'name': 'meta.structure.dictionary.value.json'
         'patterns': [
+          {
+            'include': '#comments'
+          }
           {
             'comment': 'the JSON object value'
             'include': '#value'
@@ -130,6 +143,29 @@
       }
       {
         'include': '#object'
+      }
+    ]
+  'comments':
+    'patterns': [
+      {
+        'match': '/{2}.*'
+        'name': 'comment.single.json'
+      }
+      {
+        'begin': '/\\*\\*(?!/)'
+        'captures':
+          '0':
+            'name': 'punctuation.definition.comment.json'
+        'end': '\\*/'
+        'name': 'comment.block.documentation.json'
+      }
+      {
+        'begin': '/\\*'
+        'captures':
+          '0':
+            'name': 'punctuation.definition.comment.json'
+        'end': '\\*/'
+        'name': 'comment.block.json'
       }
     ]
 'scopeName': 'source.json'

--- a/settings/language-json.cson
+++ b/settings/language-json.cson
@@ -3,3 +3,4 @@
     'foldEndPattern': '(?x:        # turn on extended mode\n\t                        ^        # a line beginning with\n\t                        \\s*      # some optional space\n\t                        [}\\]]    # and the close of an object or array\n\t                      )'
     'increaseIndentPattern': '^.*(\\{[^}]*|\\[[^\\]]*)$'
     'decreaseIndentPattern': '^\\s*[}\\]],?\\s*$'
+    'commentStart': '// '


### PR DESCRIPTION
Ass per title, this PR adds comments support for JSON.  It also defaults comment style to `//` which makes sense for JSON.

Fixes #28
Fixes #12
