### PR TITLE
Add gltf to fileTypes.

### DIFF
--- a/grammars/json.cson
+++ b/grammars/json.cson
@@ -2,6 +2,7 @@
   'babelrc'
   'bowerrc'
   'geojson'
+  'gltf'
   'ipynb'
   'jscsrc'
   'jshintrc'


### PR DESCRIPTION
Adding gltf to fileTypes allows Atom to colorize and collapse gltf files.