### PR TITLE
Recognize `.asvc` files as JSON grammar.

### DIFF
--- a/grammars/json.cson
+++ b/grammars/json.cson
@@ -1,4 +1,5 @@
 'fileTypes': [
+  'avsc'
   'babelrc'
   'bowerrc'
   'geojson'


### PR DESCRIPTION
AVRO Schema (avsc) files are JSON files. See
https://avro.apache.org/docs/1.7.7/gettingstartedjava.html for details.