### PR TITLE
add composer.lock files

### DIFF
--- a/grammars/json.cson
+++ b/grammars/json.cson
@@ -2,6 +2,7 @@
   'avsc'
   'babelrc'
   'bowerrc'
+  'composer.lock'
   'geojson'
   'gltf'
   'ipynb'


### PR DESCRIPTION
The [`composer.lock`](https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file) file is created by a PHP package manager called [Composer](https://en.wikipedia.org/wiki/Composer_%28software%29) and is written in JSON.

It is mostly generated by `composer` commands, rather than being edited by hand, but for the times when you actually need to look in one, it would be nice to have the syntax automatically set correctly.