### PR TITLE
Add .tern-project and .tern-config to file types

### DIFF
--- a/grammars/json.cson
+++ b/grammars/json.cson
@@ -16,6 +16,8 @@
   'ldjson'
   'schema'
   'template'
+  'tern-config'
+  'tern-project'
   'topojson'
   'webapp'
 ]


### PR DESCRIPTION
Adds [ternjs](http://ternjs.net/) config file types to grammar file.
`.tern-project` and `.tern-config` is documented on below url.
http://ternjs.net/doc/manual.html#server

Thanks!