### PR TITLE
Mark trailing commas as syntax errors

### DIFF
--- a/grammars/json.cson
+++ b/grammars/json.cson
@@ -33,9 +33,11 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.array.begin.json'
-    'end': '\\]'
+    'end': '(,?)[\\s\\n]*(\\])'
     'endCaptures':
-      '0':
+      '1':
+        'name': 'invalid.illegal.trailing-array-separator.json'
+      '2':
         'name': 'punctuation.definition.array.end.json'
     'name': 'meta.structure.array.json'
     'patterns': [

--- a/grammars/json.cson
+++ b/grammars/json.cson
@@ -81,9 +81,11 @@
         'beginCaptures':
           '0':
             'name': 'punctuation.separator.dictionary.key-value.json'
-        'end': '(,)|(?=\\})'
+        'end': '(,)(?=[\\s\\n]*\\})|(,)|(?=\\})'
         'endCaptures':
           '1':
+            'name': 'invalid.illegal.trailing-dictionary-separator.json'
+          '2':
             'name': 'punctuation.separator.dictionary.pair.json'
         'name': 'meta.structure.dictionary.value.json'
         'patterns': [

--- a/spec/json-spec.coffee
+++ b/spec/json-spec.coffee
@@ -77,3 +77,32 @@ describe "JSON grammar", ->
     expect(tokens[23]).toEqual value: 'bar', scopes: stringValueScopes
     expect(tokens[24]).toEqual value: '"', scopes: [stringValueScopes..., 'punctuation.definition.string.end.json']
     expect(tokens[25]).toEqual value: '}', scopes: [baseScopes..., 'punctuation.definition.dictionary.end.json']
+
+  it "identifies trailing commas in objects", ->
+    baseScopes = ['source.json', 'meta.structure.dictionary.json']
+    keyScopes = [baseScopes..., 'string.quoted.double.json']
+    keyBeginScopes = [keyScopes..., 'punctuation.definition.string.begin.json']
+    keyEndScopes = [keyScopes..., 'punctuation.definition.string.end.json']
+    valueScopes = [baseScopes..., 'meta.structure.dictionary.value.json']
+    keyValueSeparatorScopes = [valueScopes..., 'punctuation.separator.dictionary.key-value.json']
+    pairSeparatorScopes = [valueScopes..., 'punctuation.separator.dictionary.pair.json']
+
+    {tokens} = grammar.tokenizeLine('{"a": 1, "b": 2, }')
+    expect(tokens[0]).toEqual value: '{', scopes: [baseScopes..., 'punctuation.definition.dictionary.begin.json']
+    expect(tokens[1]).toEqual value: '"', scopes: keyBeginScopes
+    expect(tokens[2]).toEqual value: 'a', scopes: keyScopes
+    expect(tokens[3]).toEqual value: '"', scopes: keyEndScopes
+    expect(tokens[4]).toEqual value: ':', scopes: keyValueSeparatorScopes
+    expect(tokens[5]).toEqual value: ' ', scopes: valueScopes
+    expect(tokens[6]).toEqual value: '1', scopes: [valueScopes..., 'constant.numeric.json']
+    expect(tokens[7]).toEqual value: ',', scopes: pairSeparatorScopes
+    expect(tokens[8]).toEqual value: ' ', scopes: baseScopes
+    expect(tokens[9]).toEqual value: '"', scopes: keyBeginScopes
+    expect(tokens[10]).toEqual value: 'b', scopes: keyScopes
+    expect(tokens[11]).toEqual value: '"', scopes: keyEndScopes
+    expect(tokens[12]).toEqual value: ':', scopes: keyValueSeparatorScopes
+    expect(tokens[13]).toEqual value: ' ', scopes: valueScopes
+    expect(tokens[14]).toEqual value: '2', scopes: [valueScopes..., 'constant.numeric.json']
+    expect(tokens[15]).toEqual value: ',', scopes: [valueScopes..., 'invalid.illegal.trailing-dictionary-separator.json']
+    expect(tokens[16]).toEqual value: ' ', scopes: baseScopes
+    expect(tokens[17]).toEqual value: '}', scopes: [baseScopes..., 'punctuation.definition.dictionary.end.json']

--- a/spec/json-spec.coffee
+++ b/spec/json-spec.coffee
@@ -28,6 +28,18 @@ describe "JSON grammar", ->
     expect(tokens[7]).toEqual value: '3', scopes: numericScopes
     expect(tokens[8]).toEqual value: ']', scopes: [baseScopes..., 'punctuation.definition.array.end.json']
 
+  it "identifies trailing commas in arrays", ->
+    baseScopes = ['source.json', 'meta.structure.array.json']
+    numericScopes = [baseScopes..., 'constant.numeric.json']
+    separatorScopes = [baseScopes..., 'punctuation.separator.array.json']
+
+    {tokens} = grammar.tokenizeLine('[1, ]')
+    expect(tokens[0]).toEqual value: '[', scopes: [baseScopes..., 'punctuation.definition.array.begin.json']
+    expect(tokens[1]).toEqual value: '1', scopes: numericScopes
+    expect(tokens[2]).toEqual value: ',', scopes: [baseScopes..., 'invalid.illegal.trailing-array-separator.json']
+    expect(tokens[3]).toEqual value: ' ', scopes: [baseScopes...]
+    expect(tokens[4]).toEqual value: ']', scopes: [baseScopes..., 'punctuation.definition.array.end.json']
+
   it "tokenizes objects", ->
     baseScopes = ['source.json', 'meta.structure.dictionary.json']
     keyScopes = [baseScopes..., 'string.quoted.double.json']


### PR DESCRIPTION
Fixes #11

The new identifiers are `invalid.illegal.trailing-array-separator.json` and `invalid.illegal.trailing-dictionary-separator.json`.