### PR TITLE
Recognize `.webmanifest` files as JSON grammar

### DIFF
--- a/grammars/json.cson
+++ b/grammars/json.cson
@@ -20,6 +20,7 @@
   'tern-project'
   'topojson'
   'webapp'
+  'webmanifest'
 ]
 'name': 'JSON'
 'patterns': [


### PR DESCRIPTION
[Web App Manifest](https://w3c.github.io/manifest/) files (having [`webmanifest`](https://w3c.github.io/manifest/#media-type-registration) as the recommended file extension) use the [JSON format](https://w3c.github.io/manifest/#abstract).

--

Cc @marcoscaceres