### PR TITLE
Add .tfstate file support

### DIFF
--- a/grammars/json.cson
+++ b/grammars/json.cson
@@ -18,6 +18,7 @@
   'template'
   'tern-config'
   'tern-project'
+  'tfstate'
   'topojson'
   'webapp'
   'webmanifest'


### PR DESCRIPTION
Terraform uses `*.tfstate` files which are JSON. From [the docs](https://www.terraform.io/docs/state/):


> Terraform stores the state of your managed infrastructure from the last time Terraform was run. By default this state is stored in a local file named "terraform.tfstate"

...

> The state is in JSON format and Terraform will promise backwards compatibility with the state file. The JSON format makes it easy to write tools around the state if you want or to modify it by hand in the case of a Terraform bug. 