### PR TITLE
Adding support for .tfstate.backup files

### DIFF
--- a/grammars/json.cson
+++ b/grammars/json.cson
@@ -19,6 +19,7 @@
   'tern-config'
   'tern-project'
   'tfstate'
+  'tfstate.backup'
   'topojson'
   'webapp'
   'webmanifest'


### PR DESCRIPTION
Besides `*.tfstate` files, Terraform also uses `*.tfstate.backup` files which are JSON. See PR #48