### PR TITLE
Add meta scope for dictionary key

### DIFF
--- a/grammars/json.cson
+++ b/grammars/json.cson
@@ -76,7 +76,14 @@
     'patterns': [
       {
         # the key
-        'include': '#string'
+        'begin': '(?=")'
+        'end': '(?<=")'
+        'name': 'meta.structure.dictionary.key.json'
+        'patterns': [
+          {
+            'include': '#string'
+          }
+        ]
       }
       {
         'begin': ':'

--- a/spec/json-spec.coffee
+++ b/spec/json-spec.coffee
@@ -42,7 +42,7 @@ describe "JSON grammar", ->
 
   it "tokenizes objects", ->
     baseScopes = ['source.json', 'meta.structure.dictionary.json']
-    keyScopes = [baseScopes..., 'string.quoted.double.json']
+    keyScopes = [baseScopes..., 'meta.structure.dictionary.key.json', 'string.quoted.double.json']
     keyBeginScopes = [keyScopes..., 'punctuation.definition.string.begin.json']
     keyEndScopes = [keyScopes..., 'punctuation.definition.string.end.json']
     valueScopes = [baseScopes..., 'meta.structure.dictionary.value.json']
@@ -80,7 +80,7 @@ describe "JSON grammar", ->
 
   it "identifies trailing commas in objects", ->
     baseScopes = ['source.json', 'meta.structure.dictionary.json']
-    keyScopes = [baseScopes..., 'string.quoted.double.json']
+    keyScopes = [baseScopes..., 'meta.structure.dictionary.key.json', 'string.quoted.double.json']
     keyBeginScopes = [keyScopes..., 'punctuation.definition.string.begin.json']
     keyEndScopes = [keyScopes..., 'punctuation.definition.string.end.json']
     valueScopes = [baseScopes..., 'meta.structure.dictionary.value.json']


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Adds a `meta.structure.dictionary.key.json` scope specifically for keys.

### Alternate Designs

None.

### Benefits

This will allow for different key and value highlighting (values already have their own `meta.structure.dictionary.value.json` scope).

### Possible Drawbacks

None.

### Applicable Issues

Fixes #2