### PR TITLE
Add .stylintrc file support

### DIFF
--- a/grammars/json.cson
+++ b/grammars/json.cson
@@ -18,6 +18,7 @@
   'ldj'
   'ldjson'
   'schema'
+  'stylintrc'
   'template'
   'tern-config'
   'tern-project'


### PR DESCRIPTION
In addition to `.jslintrc`, I added [`.eslintrc`](http://eslint.org/docs/user-guide/configuring#configuration-file-formats) and [`.stylintrc`](https://github.com/SimenB/stylint#custom-configuration) handling.