### PR TITLE
Add .htmlhintrc file support

### DIFF
--- a/grammars/json.cson
+++ b/grammars/json.cson
@@ -7,6 +7,7 @@
   'composer.lock'
   'geojson'
   'gltf'
+  'htmlhintrc'
   'ipynb'
   'jscsrc'
   'jshintrc'


### PR DESCRIPTION
Adds support for [HTMLHint](https://github.com/yaniswang/HTMLHint) configuration file.

More about `.htmlhintrc`:
https://github.com/yaniswang/HTMLHint/wiki/Usage#about-rules