### PR TITLE
Add support for .json-patch extension

### DIFF
--- a/grammars/json.cson
+++ b/grammars/json.cson
@@ -15,6 +15,7 @@
   'json'
   'jsonl'
   'jsonld'
+  'json-patch'
   'languagebabel'
   'ldj'
   'ldjson'


### PR DESCRIPTION
### Description of the Change

Accordingly to RFC 6902 (see source 1) and IANA (see source 2), the
extension for json patches is .json-patch. As this file is plain JSON,
and because there's no specific plugin for that format (not even sure
that'd be needed), IMHO the best at this time is to add this extension to
the list of supported file types.

Sources:
1. RFC 6092, section "IANA Considerations":
   https://tools.ietf.org/html/rfc6902
2. IANA assignement:
   https://www.iana.org/assignments/media-types/application/json-patch+json
