### PR TITLE
Add HAR to JSON filetypes

### DIFF
--- a/grammars/json.cson
+++ b/grammars/json.cson
@@ -7,6 +7,7 @@
   'composer.lock'
   'geojson'
   'gltf'
+  'har'
   'htmlhintrc'
   'ipynb'
   'jscsrc'


### PR DESCRIPTION
### Description of the Change
Add [HTTP archive](https://w3c.github.io/web-performance/specs/HAR/Overview.html#sec-har) extension to the filetypes.