### PR TITLE
Add support for .har files

### DIFF
--- a/grammars/json.cson
+++ b/grammars/json.cson
@@ -7,6 +7,7 @@
   'composer.lock'
   'geojson'
   'gltf'
+  'har'
   'htmlhintrc'
   'ipynb'
   'jscsrc'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

HAR (HTTP Archive Format) is a file type for representing network data that is produced by tools such as Chrome DevTools. It is a JSON format, and it would be great if Atom's `language-json` highlighted `.har` files when viewing them in Atom.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

N/A

### Benefits

<!-- What benefits will be realized by the code change? -->

Tokenization and syntax highlighting for HAR files.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None that I can think of.

### Applicable Issues

<!-- Enter any applicable Issues here -->

N/A
