### PR TITLE
Scope link as string and add scope for "

### DIFF
--- a/grammars/tree-sitter-json.cson
+++ b/grammars/tree-sitter-json.cson
@@ -73,4 +73,4 @@ scopes:
   'array > ","': 'punctuation.separator.array'
   '"["': 'punctuation.definition.array.begin'
   '"]"': 'punctuation.definition.array.end'
-  '"\\""': 'punctuation.definition.string.begin.json'
+  '"\\""': 'punctuation.definition.string.json'

--- a/grammars/tree-sitter-json.cson
+++ b/grammars/tree-sitter-json.cson
@@ -53,7 +53,7 @@ scopes:
   'string': [
       {
         match: '^"https?://',
-        scopes: 'markup.underline.link'
+        scopes: 'string.quoted.double.markup.underline.link'
       }
       'string.quoted.double'
     ]
@@ -73,3 +73,4 @@ scopes:
   'array > ","': 'punctuation.separator.array'
   '"["': 'punctuation.definition.array.begin'
   '"]"': 'punctuation.definition.array.end'
+  '"\\""': 'punctuation.definition.string.begin.json'


### PR DESCRIPTION
### Description of the Change

This PR adds the `string.quoted.double` scope as discussed in https://github.com/atom/language-json/pull/68, specifically https://github.com/atom/language-json/pull/68#issuecomment-492426354 

It also adds a scope for an anonymous `"` node as made possible in https://github.com/atom/atom/pull/19336

### Alternate Designs

N/A

### Benefits

Closer to TextMate with the benefits of tree-sitter

### Possible Drawbacks

We still scope `"` as `markup.underline.link`. Textmate doesn't, it just scopes it as `string.quoted.double`. A lot of themes style any `markup.underline.link` as a link. So generally quotes are still styled as a link.

### Applicable Issues

N/A. Cleaning up after adding tree-sitter-json

/cc: @50Wliu @nathansobo @caleb531