### PR TITLE
Restore ability to using "Link: Open" command for JSON strings containing hyperlinks

### DIFF
--- a/grammars/tree-sitter-json.cson
+++ b/grammars/tree-sitter-json.cson
@@ -50,7 +50,7 @@ scopes:
 
   'object': 'meta.structure.dictionary.json'
 
-  'string': 'string.quoted.double.json'
+  'string': 'string.quoted.double'
 
   'string_content': [
     { match: /^http:\/\//, scopes: 'markup.underline.link.http.hyperlink' }

--- a/grammars/tree-sitter-json.cson
+++ b/grammars/tree-sitter-json.cson
@@ -50,13 +50,13 @@ scopes:
 
   'object': 'meta.structure.dictionary.json'
 
-  'string': [
-      {
-        match: '^"https?://',
-        scopes: 'string.quoted.double.markup.underline.link'
-      }
-      'string.quoted.double'
-    ]
+  'string': 'string.quoted.double'
+
+  'string_content': [
+    { match: /^http:\/\//, scopes: 'markup.underline.link.http.hyperlink' }
+    { match: /^https:\/\//, scopes: 'markup.underline.link.https.hyperlink' }
+  ]
+
   'pair > string:nth-child(0)': 'string.quoted.double.dictionary.key.json'
 
   'escape_sequence': 'constant.character.escape'

--- a/grammars/tree-sitter-json.cson
+++ b/grammars/tree-sitter-json.cson
@@ -50,7 +50,7 @@ scopes:
 
   'object': 'meta.structure.dictionary.json'
 
-  'string': 'string.quoted.double'
+  'string': 'string.quoted.double.json'
 
   'string_content': [
     { match: /^http:\/\//, scopes: 'markup.underline.link.http.hyperlink' }

--- a/package-lock.json
+++ b/package-lock.json
@@ -146,9 +146,8 @@
       "dev": true
     },
     "tree-sitter-json": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/tree-sitter-json/-/tree-sitter-json-0.13.1.tgz",
-      "integrity": "sha512-3Z6CC5vaEX+vvCmZ5ULCYVaILQVqkhv1Yw7Wo7ARlVsOAehVEj5JCag+lyU4RGkZY65tgYyrkw5s0Anv4ij4kQ==",
+      "version": "git://github.com/jasonrudolph/tree-sitter-json.git#e83c1bcaa3379ce42be9d3a7c70b6fa8ff2c2e1d",
+      "from": "git://github.com/jasonrudolph/tree-sitter-json.git#e83c1bcaa3379ce42be9d3a7c70b6fa8ff2c2e1d",
       "requires": {
         "nan": "^2.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -146,8 +146,8 @@
       "dev": true
     },
     "tree-sitter-json": {
-      "version": "git://github.com/jasonrudolph/tree-sitter-json.git#e83c1bcaa3379ce42be9d3a7c70b6fa8ff2c2e1d",
-      "from": "git://github.com/jasonrudolph/tree-sitter-json.git#e83c1bcaa3379ce42be9d3a7c70b6fa8ff2c2e1d",
+      "version": "git://github.com/tree-sitter/tree-sitter-json.git#337f55be9b9b1ccb0baa7763bfe014a94acea7ea",
+      "from": "git://github.com/tree-sitter/tree-sitter-json.git#v0.14.0",
       "requires": {
         "nan": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "coffeelint": "^1.10.1"
   },
   "dependencies": {
-    "tree-sitter-json": "git://github.com/jasonrudolph/tree-sitter-json.git#e83c1bcaa3379ce42be9d3a7c70b6fa8ff2c2e1d"
+    "tree-sitter-json": "git://github.com/tree-sitter/tree-sitter-json.git#v0.14.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "coffeelint": "^1.10.1"
   },
   "dependencies": {
-    "tree-sitter-json": "^0.13.1"
+    "tree-sitter-json": "git://github.com/jasonrudolph/tree-sitter-json.git#e83c1bcaa3379ce42be9d3a7c70b6fa8ff2c2e1d"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/19353

### Background

When viewing a JSON file in **Atom 1.37.0**, when the cursor is positioned inside a double-quoted string containing a URL, the scopes appear as follows:

<img width="472" alt="atom-stable" src="https://user-images.githubusercontent.com/2988/58034180-f2c2b900-7af3-11e9-994f-75ee27198050.png">

The `string.quoted.double.json` scope applies to the string as a whole (including the quotes) and the `markup.underline.link.https.hyperlink` scope applies to the URL on its own (without the surrounding quotes).

In **Atom 1.39.0-nightly9**, the scopes appear as follows:

<img width="483" alt="atom-nightly" src="https://user-images.githubusercontent.com/2988/58034179-f2c2b900-7af3-11e9-9101-2e5e5a34e186.png">

Note that there's no distinction between the double quoted string and the URL. The `string.quoted.double.markup.underline.link` scope applies to the string as a whole (including the quotes).

This change causes a regression described in https://github.com/atom/atom/issues/19353. The [link package](https://github.com/atom/atom/tree/0ab0e6595d37e56ce72d1487720c6074c07670e3/packages/link) fetches the [buffer contents for the `markup.underline.link` scope](https://github.com/atom/atom/blob/0ab0e6595d37e56ce72d1487720c6074c07670e3/packages/link/lib/link.js#L59), and those contents now include surrounding quotes. When the link package tries to open the URL, it fails because it's not getting a raw URL; it's getting a URL surrounded by quotes (e.g., `"http://example.com"` instead of `http://example.com`).

### Description of the Change

Building on the enhancement in https://github.com/tree-sitter/tree-sitter-json/pull/8, this pull request restores the previous behavior: when a string contains a URL, the string as a whole is given the `string.quoted.double.json` scope, and the inner content of the string is given the `markup.underlink.link.https.hyperlink` scope:

<img width="467" alt="Screen Shot 2019-05-22 at 11 00 35 AM" src="https://user-images.githubusercontent.com/2988/58185337-e15ae780-7c80-11e9-930d-6efc1d11cde4.png">

Note: If the URL is an HTTP URL instead of an HTTPS URL, the scope is `markup.underlink.link.http.hyperlink`.

### Alternate Designs

As described in https://github.com/atom/atom/issues/19353#issuecomment-494044274, we considered changing the link package to strip the surrounding quotes before attempting to open the link. However, that's a patch that only benefits the link package, and doesn't help any other packages that may have been affected by the change in scopes between Atom 1.37.0 and Atom Atom 1.39.0-nightly9.

### Benefits

Fixes https://github.com/atom/atom/issues/19353

### Possible Drawbacks

None that I'm aware of.

### Applicable Issues

https://github.com/atom/language-json/pull/73
