### PR TITLE
Highlight invalid/illegal JSON syntax in tree-sitter grammar

### DIFF
--- a/grammars/tree-sitter-json.cson
+++ b/grammars/tree-sitter-json.cson
@@ -74,3 +74,5 @@ scopes:
   '"["': 'punctuation.definition.array.begin'
   '"]"': 'punctuation.definition.array.end'
   '"\\""': 'punctuation.definition.string.json'
+
+  'ERROR': 'invalid.illegal'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

This PR adds simple highlighting of invalid/illegal markup in tree-sitter-parsed JSON files. This is similar to how the first-mate JSON grammar highlighted syntax errors in JSON files.

**Current first-mate:**  
<img width="624" alt="json-invalid-current-first-mate" src="https://user-images.githubusercontent.com/872474/59730862-d0a67e80-91f8-11e9-910e-a202b804fc29.png">

**Current tree-sitter:**  
<img width="628" alt="json-invalid-current" src="https://user-images.githubusercontent.com/872474/59730519-8bce1800-91f7-11e9-8951-67d1a1516cba.png">

**Proposed tree-sitter:**  
<img width="623" alt="json-invalid-new" src="https://user-images.githubusercontent.com/872474/59730527-938dbc80-91f7-11e9-9418-dfd3ce77add9.png">

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

The first-mate grammar tokenizes different kinds of invalid syntax (e.g. missing comma vs. unterminated strings). I chose not to go this deep with my changes for the tree-sitter grammar here, since `'ERROR': 'invalid.illegal'` covers the majority of cases pretty clearly.

I could've also used a scope other than `invalid.illegal`, though since I am not distinguishing between different types of errors per the above, I felt no need to qualify the scope any further.

### Benefits

<!-- What benefits will be realized by the code change? -->

It would be much more obvious when your JSON file contains invalid/illegal syntax, such as a missing comma or extraneous text.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Some people may find it distracting or difficult to read, especially if you are writing a JSON file by hand. But since JSON and its ecosystem of parsers demand such strict syntax, I think the tradeoff is worth it to more easily catch syntax errors on the spot.

<img width="164" alt="Screen Shot 2019-06-18 at 6 35 52 PM" src="https://user-images.githubusercontent.com/872474/59730630-ee271880-91f7-11e9-8126-f9f5ec1d8b94.png">

### Applicable Issues

<!-- Enter any applicable Issues here -->

N/A
